### PR TITLE
Use appveyor logger for dotnet tests

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -38,6 +38,6 @@ for:
       - export CCM_SSL_PATH=$CCM_PATH/ssl
       - dotnet --version
       - dotnet restore src
-      - dotnet test src/Cassandra.IntegrationTests/Cassandra.IntegrationTests.csproj -f netcoreapp2.1 -c Release --filter TestCategory=serverapi
+      - dotnet test src/Cassandra.IntegrationTests/Cassandra.IntegrationTests.csproj -f netcoreapp2.1 -c Release --filter TestCategory=serverapi --logger:Appveyor
 
 build: off


### PR DESCRIPTION
Using the appveyor logger allows us to see the test report like this: https://ci.appveyor.com/project/DataStax/csharp-driver/builds/30884165/job/1ddmnvo4hl5s8qak/tests