### PR TITLE
Add the DataStax C/C++ driver

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,6 +6,7 @@ environment:
     - DRIVER_REPO: "nodejs-driver"
     - DRIVER_REPO: "java-driver"
     - DRIVER_REPO: "csharp-driver"
+    - DRIVER_REPO: "cpp-driver"
 
 install:
 - source ./install.sh
@@ -39,5 +40,19 @@ for:
       - dotnet --version
       - dotnet restore src
       - dotnet test src/Cassandra.IntegrationTests/Cassandra.IntegrationTests.csproj -f netcoreapp2.1 -c Release --filter TestCategory=serverapi --logger:Appveyor
+  - matrix:
+      only:
+        - DRIVER_REPO: "cpp-driver"
+    test_script:
+      - git checkout ${DRIVER_LATEST_TAG}
+      - export CI_INTEGRATION_ENABLED=true
+      - export OS_VERSION=ubuntu/bionic
+      - export OS_DISTRO=ubuntu
+      - export SMOKE_TEST_FILTER=BasicsTests*:CassandraTypes/*
+      - . .build.sh
+      - build_driver 'CASS'
+      - build/cassandra-integration-tests --category=cassandra --gtest_filter=${SMOKE_TEST_FILTER} --gtest_output=xml:integration-smoke-test-results.xml --version=${CCM_VERSION}
+    on_finish:
+      - find "${APPVEYOR_BUILD_FOLDER}" -type f -name 'integration-smoke-test-results.xml' -print0 | xargs -0 -I '{}' curl -F 'file=@{}' "https://ci.appveyor.com/api/testresults/junit/${APPVEYOR_JOB_ID}"
 
 build: off

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -15,26 +15,26 @@ for:
       only:
         - DRIVER_REPO: "nodejs-driver"
     test_script:
-      # TODO: Use stable $DRIVER_TAG
+      # TODO: Use stable ${DRIVER_LATEST_TAG}
       - git checkout master
       - export TEST_TRACE=on
       - npm install
       - npm run server_api
   - matrix:
       only:
-          - DRIVER_REPO: "java-driver"
+        - DRIVER_REPO: "java-driver"
     test_script:
-      - git checkout $DRIVER_TAG
+      - git checkout ${DRIVER_LATEST_TAG}
       - mvn -B -V install -DskipTests
-      - mvn -B -V verify --batch-mode --show-version -Dccm.version=$CCM_VERSION -DskipSerialITs -DskipIsolatedITs -Dmaven.javadoc.skip=true
+      - mvn -B -V verify --batch-mode --show-version -Dccm.version=${CCM_VERSION} -DskipSerialITs -DskipIsolatedITs -Dmaven.javadoc.skip=true
   - matrix:
       only:
         - DRIVER_REPO: "csharp-driver"
     test_script:
-      # TODO: Use stable $DRIVER_TAG
+      # TODO: Use stable ${DRIVER_LATEST_TAG}
       - git checkout master
       - export DOTNET_CLI_TELEMETRY_OPTOUT=1
-      - export CASSANDRA_VERSION=$CCM_VERSION
+      - export CASSANDRA_VERSION=${CCM_VERSION}
       - export CCM_SSL_PATH=$CCM_PATH/ssl
       - dotnet --version
       - dotnet restore src

--- a/install.sh
+++ b/install.sh
@@ -1,5 +1,11 @@
 #!/bin/bash
 
+# Install driver specific packages
+sudo apt-get update
+if [ "${DRIVER_REPO}" = 'cpp-driver' ]; then
+  sudo apt-get install -y debhelper libkrb5-dev libssl-dev libuv1-dev zlib1g-dev
+fi
+
 # Install CCM
 git clone --branch master --single-branch https://github.com/riptano/ccm.git
 pushd ccm || exit

--- a/install.sh
+++ b/install.sh
@@ -11,9 +11,9 @@ export CCM_PATH="$(pwd)/ccm"
 
 # Download and install Apache Cassandra
 export INSTALL_DIR="${HOME}/.ccm/repository/${CCM_VERSION}"
-echo $INSTALL_DIR
-mkdir -p $INSTALL_DIR
-wget $SERVER_PACKAGE_URL -O server.tar.gz
+echo ${INSTALL_DIR}
+mkdir -p ${INSTALL_DIR}
+wget ${SERVER_PACKAGE_URL} -O server.tar.gz
 tar xzf server.tar.gz -C ${INSTALL_DIR} --strip-components=1 || exit
 
 # Add 0.version.txt file for ccm
@@ -21,11 +21,12 @@ VERSION_TOKENS=($(echo ${CCM_VERSION} | sed -e "s/[\\.|-]/ /g"))
 echo "${VERSION_TOKENS[0]}.${VERSION_TOKENS[1]}.${VERSION_TOKENS[2]}" > "${INSTALL_DIR}/0.version.txt"
 
 # Verify that ccm cluster creation succeeds
-ccm create test -v $CCM_VERSION
+ccm create test -v ${CCM_VERSION}
 ccm remove test
 
 # Clone the driver repository
-git clone https://github.com/datastax/$DRIVER_REPO
-cd $DRIVER_REPO || exit
+git clone https://github.com/datastax/${DRIVER_REPO}
+cd ${DRIVER_REPO} || exit
 git fetch --tags
-export DRIVER_TAG=$(git tag | grep -P '^v?\d+\.\d+\.\d+$' | tail -1)
+export DRIVER_LATEST_TAG=$(git describe --tags `git rev-list --tags --max-count=1`)
+echo ${DRIVER_LATEST_TAG}

--- a/install.sh
+++ b/install.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+echo "Smoke tests for Apache Cassandra ${CCM_VERSION} using ${DRIVER_REPO}"
+echo "Using ${SERVER_PACKAGE_URL}"
+
 # Install driver specific packages
 sudo apt-get update
 if [ "${DRIVER_REPO}" = 'cpp-driver' ]; then


### PR DESCRIPTION
This PR adds the C/C++ driver to the Apache Cassandra® smoke test. A separate commit was done which made variable usage consistent and fixed a issue when getting the latest tag for the driver repo.