### PR TITLE
Add server version matrix and determine latest server version

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,29 +2,15 @@
 
 Run a subset of the integration test suite of each DataStax driver in order to smoke test Apache Cassandra releases.
 
-## Environment variables
-
-The build requires two environment variables to be set: `SERVER_PACKAGE_URL` and `CCM_VERSION`.
-
-For example:
-
-```bash
-export SERVER_PACKAGE_URL=https://dist.apache.org/repos/dist/release/cassandra/3.11.6/apache-cassandra-3.11.6-bin.tar.gz
-export CCM_VERSION=3.11.6
-```
-
 ## AppVeyor Project
 
 https://ci.appveyor.com/project/DataStax/cassandra-drivers-smoke-test/
 
-The environment variables on AppVeyor are set using the [Settings
- UI](https://ci.appveyor.com/project/DataStax/cassandra-drivers-smoke-test/settings).
- 
 ## Other CI Service Providers
 
 This project currently uses [AppVeyor](https://www.appveyor.com/), if needed, it can easily be migrated to other CI
  Service Provider as all the logic on `install.sh` is provider agnostic.
- 
+
 ## License
 
 © DataStax, Inc.

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,10 +3,22 @@ stack: node 12, jdk 8, python 2
 
 environment:
   matrix:
-    - DRIVER_REPO: "nodejs-driver"
-    - DRIVER_REPO: "java-driver"
-    - DRIVER_REPO: "csharp-driver"
-    - DRIVER_REPO: "cpp-driver"
+    - DRIVER_REPO: nodejs-driver
+      SERVER_VERSION: 3.11
+    - DRIVER_REPO: nodejs-driver
+      SERVER_VERSION: 4.0
+    - DRIVER_REPO: java-driver
+      SERVER_VERSION: 3.11
+    - DRIVER_REPO: java-driver
+      SERVER_VERSION: 4.0
+    - DRIVER_REPO: csharp-driver
+      SERVER_VERSION: 3.11
+    - DRIVER_REPO: csharp-driver
+      SERVER_VERSION: 4.0
+    - DRIVER_REPO: cpp-driver
+      SERVER_VERSION: 3.11
+    - DRIVER_REPO: cpp-driver
+      SERVER_VERSION: 4.0
 
 install:
 - source ./install.sh
@@ -14,7 +26,7 @@ install:
 for:
   - matrix:
       only:
-        - DRIVER_REPO: "nodejs-driver"
+        - DRIVER_REPO: nodejs-driver
     test_script:
       # TODO: Use stable ${DRIVER_LATEST_TAG}
       - git checkout master
@@ -23,14 +35,14 @@ for:
       - npm run server_api
   - matrix:
       only:
-        - DRIVER_REPO: "java-driver"
+        - DRIVER_REPO: java-driver
     test_script:
       - git checkout ${DRIVER_LATEST_TAG}
       - mvn -B -V install -DskipTests
       - mvn -B -V verify --batch-mode --show-version -Dccm.version=${CCM_VERSION} -DskipSerialITs -DskipIsolatedITs -Dmaven.javadoc.skip=true
   - matrix:
       only:
-        - DRIVER_REPO: "csharp-driver"
+        - DRIVER_REPO: csharp-driver
     test_script:
       # TODO: Use stable ${DRIVER_LATEST_TAG}
       - git checkout master
@@ -42,7 +54,7 @@ for:
       - dotnet test src/Cassandra.IntegrationTests/Cassandra.IntegrationTests.csproj -f netcoreapp2.1 -c Release --filter TestCategory=serverapi --logger:Appveyor
   - matrix:
       only:
-        - DRIVER_REPO: "cpp-driver"
+        - DRIVER_REPO: cpp-driver
     test_script:
       - git checkout ${DRIVER_LATEST_TAG}
       - export CI_INTEGRATION_ENABLED=true

--- a/install.sh
+++ b/install.sh
@@ -1,13 +1,15 @@
 #!/bin/bash
 
 # Determine the Apache Cassandra version to download
-SERVER_PACKAGE_BASE_URL=https://dist.apache.org/repos/dist/release/cassandra
+SERVER_PACKAGE_BASE_URL=https://dist.apache.org/repos/dist/release/cassandra/
 LATEST_SERVER_VERSION=$(curl -sS ${SERVER_PACKAGE_BASE_URL} | \
                         grep -Po "href=[\"']\K[^'\"]+" | \
                         grep -P '\d+.\d+' | \
                         sed -e 's/\///' | \
                         grep ${SERVER_VERSION})
-SERVER_PACKAGE_URL=${SERVER_PACKAGE_BASE_URL}/${LATEST_SERVER_VERSION}/apache-cassandra-${LATEST_SERVER_VERSION}-bin.tar.gz
+[ -z "${LATEST_SERVER_VERSION}" ] && echo "Could not determine latest server version" && exit
+SERVER_FILENAME=apache-cassandra-${LATEST_SERVER_VERSION}-bin.tar.gz
+SERVER_PACKAGE_URL=${SERVER_PACKAGE_BASE_URL}/${LATEST_SERVER_VERSION}/${SERVER_FILENAME}
 CCM_VERSION_TOKENS=($(echo ${LATEST_SERVER_VERSION} | \
                       grep -Po '(\d+\.)+\d+' | \
                       sed -e "s/\\./ /g"))
@@ -41,8 +43,8 @@ export CCM_PATH="$(pwd)/ccm"
 export INSTALL_DIR="${HOME}/.ccm/repository/${CCM_VERSION}"
 echo ${INSTALL_DIR}
 mkdir -p ${INSTALL_DIR}
-wget ${SERVER_PACKAGE_URL} -O server.tar.gz
-tar xzf server.tar.gz -C ${INSTALL_DIR} --strip-components=1 || exit
+wget ${SERVER_PACKAGE_URL} -O ${SERVER_FILENAME}
+tar xzf ${SERVER_FILENAME} -C ${INSTALL_DIR} --strip-components=1 || exit
 
 # Add 0.version.txt file for CCM
 echo "${CCM_VERSION}" > "${INSTALL_DIR}/0.version.txt"

--- a/install.sh
+++ b/install.sh
@@ -1,5 +1,15 @@
 #!/bin/bash
 
+# Determine the Apache Cassandra version to download
+SERVER_PACKAGE_BASE_URL=https://dist.apache.org/repos/dist/release/cassandra/
+LATEST_SERVER_VERSION=$(curl -sS ${SERVER_PACKAGE_BASE_URL} | \
+                        grep -Po "href=[\"']\K[^'\"]+" | \
+                        grep -P '\d+.\d+' | \
+                        sed -e 's/\///' | \
+                        grep ${SERVER_VERSION})
+SERVER_PACKAGE_URL=${SERVER_PACKAGE_BASE_URL}/${LATEST_SERVER_VERSION}/apache-cassandra-${LATEST_SERVER_VERSION}-bin.tar.gz
+CCM_VERSION=${LATEST_SERVER_VERSION}
+
 echo "Smoke tests for Apache Cassandra ${CCM_VERSION} using ${DRIVER_REPO}"
 echo "Using ${SERVER_PACKAGE_URL}"
 


### PR DESCRIPTION
This PR removes the requirement for assigning environment variables in AppVeyor or any other future CI platform chosen. This also add `SERVER_VERSION` to the environment matrix to allow for multiple Apache Cassandra® versions to be smoke tested.