### PR TITLE
Add windows to the matrix

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -40,7 +40,7 @@ for:
   - matrix:
       only:
         - DRIVER_REPO: "csharp-driver"
-        - APPVEYOR_BUILD_WORKER_IMAGE: Ubuntu
+          APPVEYOR_BUILD_WORKER_IMAGE: Ubuntu
     test_script:
       # TODO: Use stable ${DRIVER_LATEST_TAG}
       - git checkout master
@@ -53,7 +53,7 @@ for:
   - matrix:
       only:
         - DRIVER_REPO: "csharp-driver"
-        - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
+          APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
     install:
       - ps: .\install_windows.ps1
     test_script:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,12 +1,17 @@
-image: Ubuntu
 stack: node 12, jdk 8, python 2
 
 environment:
   matrix:
-    - DRIVER_REPO: "nodejs-driver"
-    - DRIVER_REPO: "java-driver"
-    - DRIVER_REPO: "csharp-driver"
-    - DRIVER_REPO: "cpp-driver"
+    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
+      DRIVER_REPO: csharp-driver
+    - APPVEYOR_BUILD_WORKER_IMAGE: Ubuntu
+      DRIVER_REPO: csharp-driver
+    - APPVEYOR_BUILD_WORKER_IMAGE: Ubuntu
+      DRIVER_REPO: java-driver
+    - APPVEYOR_BUILD_WORKER_IMAGE: Ubuntu
+      DRIVER_REPO: nodejs-driver
+    - APPVEYOR_BUILD_WORKER_IMAGE: Ubuntu
+      DRIVER_REPO: cpp-driver
 
 install:
 - source ./install.sh
@@ -35,6 +40,7 @@ for:
   - matrix:
       only:
         - DRIVER_REPO: "csharp-driver"
+        - APPVEYOR_BUILD_WORKER_IMAGE: Ubuntu
     test_script:
       # TODO: Use stable ${DRIVER_LATEST_TAG}
       - git checkout master
@@ -44,6 +50,25 @@ for:
       - dotnet --version
       - dotnet restore src
       - dotnet test src/Cassandra.IntegrationTests/Cassandra.IntegrationTests.csproj -f netcoreapp2.1 -c Release --filter TestCategory=serverapi --logger:Appveyor
+  - matrix:
+      only:
+        - DRIVER_REPO: "csharp-driver"
+        - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
+    install:
+      - ps: .\install_windows.ps1
+    test_script:
+    - ps: |
+        git checkout master
+
+        $env:CASSANDRA_VERSION=$env:CCM_VERSION
+        $env:CCM_SSL_PATH=$env:CCM_PATH\ssl
+        $env:DOTNET_CLI_TELEMETRY_OPTOUT=1
+
+        dotnet --info
+        dotnet restore src
+        dotnet build src\Cassandra.sln -c Release
+
+        dotnet test src\Cassandra.IntegrationTests\Cassandra.IntegrationTests.csproj -c Release -f net461 --filter "(TestCategory=serverapi)" --logger:Appveyor
   - matrix:
       only:
         - DRIVER_REPO: "cpp-driver"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -61,7 +61,7 @@ for:
         git checkout master
 
         $env:CASSANDRA_VERSION=$env:CCM_VERSION
-        $env:CCM_SSL_PATH=$env:CCM_PATH\ssl
+        $env:CCM_SSL_PATH="$env:CCM_PATH\ssl"
         $env:DOTNET_CLI_TELEMETRY_OPTOUT=1
 
         dotnet --info

--- a/install_windows.ps1
+++ b/install_windows.ps1
@@ -47,7 +47,7 @@ If (!(Test-Path $jce_indicator)) {
 Write-Host "Installing CCM and its dependencies"
 Start-Process python -ArgumentList "-m pip install psutil pyYaml six" -Wait -NoNewWindow
 
-$env:CCM_PATH="C:$($env:USERPROFILE)\ccm"
+$env:CCM_PATH="$env:USERPROFILE\ccm"
 
 If (!(Test-Path $env:CCM_PATH)) {
   Write-Host "Cloning git ccm... $($env:CCM_PATH)"
@@ -69,7 +69,7 @@ Set-ExecutionPolicy -ExecutionPolicy Unrestricted -Scope Process
 $INSTALL_PATH = "$env:USERPROFILE\.ccm\repository\$env:CCM_VERSION"
 
 New-Item -ItemType Directory -Path $INSTALL_PATH
-Invoke-WebRequest -Uri $SERVER_PACKAGE_URL -OutFile server-bin.tar.gz
+Invoke-WebRequest -Uri $env:SERVER_PACKAGE_URL -OutFile server-bin.tar.gz
 tar xzf server-bin.tar.gz -C $INSTALL_PATH --strip-components=1
 
 $MyPath = "$INSTALL_PATH\0.version.txt"

--- a/install_windows.ps1
+++ b/install_windows.ps1
@@ -58,7 +58,7 @@ If (!(Test-Path $env:CCM_PATH)) {
   popd
 }
 
-$sslPath="C:$($env:USERPROFILE)\ssl"
+$sslPath="$env:USERPROFILE\ssl"
 If (!(Test-Path $sslPath)) {
   Copy-Item "$env:CCM_PATH\ssl" -Destination $sslPath -Recurse
 }

--- a/install_windows.ps1
+++ b/install_windows.ps1
@@ -1,0 +1,86 @@
+$env:JAVA_HOME="C:\Program Files\Java\jdk1.8.0"
+$env:PYTHON="C:\Python27-x64"
+$env:PATH="$($env:PYTHON);$($env:PYTHON)\Scripts;$($env:JAVA_HOME)\bin;$($env:PATH)"
+$env:PATHEXT="$($env:PATHEXT);.PY"
+
+Write-Host "Smoke tests for Apache Cassandra $env:CCM_VERSION using $env:DRIVER_REPO on Windows"
+Write-Host "Using $env:SERVER_PACKAGE_URL"
+
+# Install Ant
+$ant_base = "$($dep_dir)\ant"
+$ant_path = "$($ant_base)\apache-ant-1.9.7"
+If (!(Test-Path $ant_path)) {
+  Write-Host "Installing Ant"
+  $ant_url = "https://www.dropbox.com/s/lgx95x1jr6s787l/apache-ant-1.9.7-bin.zip?dl=1"
+  $ant_zip = "C:\Users\appveyor\apache-ant-1.9.7-bin.zip"
+  (new-object System.Net.WebClient).DownloadFile($ant_url, $ant_zip)
+  [System.IO.Compression.ZipFile]::ExtractToDirectory($ant_zip, $ant_base)
+}
+$env:PATH="$($ant_path)\bin;$($env:PATH)"
+
+Write-Host "Installing java Cryptographic Extensions, needed for SSL..."
+# Install Java Cryptographic Extensions, needed for SSL.
+$target = "$($env:JAVA_HOME)\jre\lib\security"
+# If this file doesn't exist we know JCE hasn't been installed.
+$jce_indicator = "$target\README.txt"
+$zip = "C:\Users\appveyor\jce_policy-8.zip"
+
+If (!(Test-Path $jce_indicator)) {
+  if(!(Test-Path $zip)) {
+    $url = "https://www.dropbox.com/s/al1e6e92cjdv7m7/jce_policy-8.zip?dl=1"
+    Write-Host "Downloading file..."
+    (new-object System.Net.WebClient).DownloadFile($url, $zip)
+    Write-Host "Download completed."
+  }
+
+  Add-Type -AssemblyName System.IO.Compression.FileSystem
+  Write-Host "Extracting zip file..."
+  [System.IO.Compression.ZipFile]::ExtractToDirectory($zip, $target)
+  Write-Host "Extraction completed."
+
+  $jcePolicyDir = "$target\UnlimitedJCEPolicyJDK8"
+  Move-Item $jcePolicyDir\* $target\ -force
+  Remove-Item $jcePolicyDir
+}
+
+# Install Python Dependencies for CCM.
+Write-Host "Installing CCM and its dependencies"
+Start-Process python -ArgumentList "-m pip install psutil pyYaml six" -Wait -NoNewWindow
+
+$env:CCM_PATH="C:$($env:USERPROFILE)\ccm"
+
+If (!(Test-Path $env:CCM_PATH)) {
+  Write-Host "Cloning git ccm... $($env:CCM_PATH)"
+  Start-Process git -ArgumentList "clone https://github.com/pcmanus/ccm.git $($env:CCM_PATH)" -Wait -NoNewWindow
+  Write-Host "git ccm cloned"
+  pushd $env:CCM_PATH
+  Start-Process python -ArgumentList "setup.py install" -Wait -NoNewWindow
+  popd
+}
+
+$sslPath="C:$($env:USERPROFILE)\ssl"
+If (!(Test-Path $sslPath)) {
+  Copy-Item "$($env:CCM_PATH)\ssl" -Destination $sslPath -Recurse
+}
+
+Write-Host "Set execution Policy"
+Set-ExecutionPolicy -ExecutionPolicy Unrestricted -Scope Process
+
+$INSTALL_PATH = "$env:USERPROFILE\.ccm\repository\$env:CCM_VERSION"
+
+New-Item -ItemType Directory -Path $INSTALL_PATH
+Invoke-WebRequest -Uri $SERVER_PACKAGE_URL -OutFile server-bin.tar.gz
+appveyor DownloadFile $SERVER_PACKAGE_URL
+tar xzf server-bin.tar.gz -C $INSTALL_PATH --strip-components=1
+
+$MyPath = "$INSTALL_PATH\0.version.txt"
+$Utf8NoBomEncoding = New-Object System.Text.UTF8Encoding $False
+[System.IO.File]::WriteAllText($MyPath, $env:CCM_VERSION, $Utf8NoBomEncoding)
+
+# Verify that ccm cluster creation succeeds
+ccm create test -v $env:CCM_VERSION
+ccm remove test
+
+# Clone the driver repository
+git clone https://github.com/datastax/$env:DRIVER_REPO
+cd $env:DRIVER_REPO

--- a/install_windows.ps1
+++ b/install_windows.ps1
@@ -7,14 +7,14 @@ Write-Host "Smoke tests for Apache Cassandra $env:CCM_VERSION using $env:DRIVER_
 Write-Host "Using $env:SERVER_PACKAGE_URL"
 
 # Install Ant
-$ant_base = "$($dep_dir)\ant"
+$ant_base = "$($env:USERPROFILE)\ant"
 $ant_path = "$($ant_base)\apache-ant-1.9.7"
 If (!(Test-Path $ant_path)) {
   Write-Host "Installing Ant"
   $ant_url = "https://www.dropbox.com/s/lgx95x1jr6s787l/apache-ant-1.9.7-bin.zip?dl=1"
   $ant_zip = "C:\Users\appveyor\apache-ant-1.9.7-bin.zip"
-  (new-object System.Net.WebClient).DownloadFile($ant_url, $ant_zip)
-  [System.IO.Compression.ZipFile]::ExtractToDirectory($ant_zip, $ant_base)
+  Invoke-WebRequest -Uri $ant_url -OutFile $ant_zip
+  expand-archive -Path $ant_zip -destinationpath $ant_base
 }
 $env:PATH="$($ant_path)\bin;$($env:PATH)"
 
@@ -29,13 +29,13 @@ If (!(Test-Path $jce_indicator)) {
   if(!(Test-Path $zip)) {
     $url = "https://www.dropbox.com/s/al1e6e92cjdv7m7/jce_policy-8.zip?dl=1"
     Write-Host "Downloading file..."
-    (new-object System.Net.WebClient).DownloadFile($url, $zip)
+    Invoke-WebRequest -Uri $url -OutFile $zip
     Write-Host "Download completed."
   }
 
   Add-Type -AssemblyName System.IO.Compression.FileSystem
   Write-Host "Extracting zip file..."
-  [System.IO.Compression.ZipFile]::ExtractToDirectory($zip, $target)
+  expand-archive -Path $zip -destinationpath $target
   Write-Host "Extraction completed."
 
   $jcePolicyDir = "$target\UnlimitedJCEPolicyJDK8"
@@ -70,7 +70,6 @@ $INSTALL_PATH = "$env:USERPROFILE\.ccm\repository\$env:CCM_VERSION"
 
 New-Item -ItemType Directory -Path $INSTALL_PATH
 Invoke-WebRequest -Uri $SERVER_PACKAGE_URL -OutFile server-bin.tar.gz
-appveyor DownloadFile $SERVER_PACKAGE_URL
 tar xzf server-bin.tar.gz -C $INSTALL_PATH --strip-components=1
 
 $MyPath = "$INSTALL_PATH\0.version.txt"

--- a/install_windows.ps1
+++ b/install_windows.ps1
@@ -60,7 +60,7 @@ If (!(Test-Path $env:CCM_PATH)) {
 
 $sslPath="C:$($env:USERPROFILE)\ssl"
 If (!(Test-Path $sslPath)) {
-  Copy-Item "$($env:CCM_PATH)\ssl" -Destination $sslPath -Recurse
+  Copy-Item "$env:CCM_PATH\ssl" -Destination $sslPath -Recurse
 }
 
 Write-Host "Set execution Policy"


### PR DESCRIPTION
With this PR, the C# driver will build for both Ubuntu and Windows while the remaining drivers continue building only on Ubuntu.

Most of the install logic on the new powershell script was copied from the appveyor_install powershell script on the C# driver repo.