### PR TITLE
Pinpoint ccm version, fix csharp tests on windows

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,8 @@
 stack: node 12, jdk 8, python 2
 
 environment:
+  global:
+    CCM_SHA_VERSION: 32e8c1126baeddc21357b414c5b8551d4540fd5f
   matrix:
     - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
       DRIVER_REPO: csharp-driver

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -50,7 +50,7 @@ for:
       - export CCM_SSL_PATH=$CCM_PATH/ssl
       - dotnet --version
       - dotnet restore src
-      - dotnet test src/Cassandra.IntegrationTests/Cassandra.IntegrationTests.csproj -f netcoreapp2.1 -c Release --filter TestCategory=serverapi --logger:Appveyor
+      - dotnet test src/Cassandra.IntegrationTests/Cassandra.IntegrationTests.csproj -f netcoreapp3.1 -c Release --filter TestCategory=serverapi --logger:Appveyor
   - matrix:
       only:
         - DRIVER_REPO: "csharp-driver"
@@ -70,7 +70,7 @@ for:
         dotnet restore src
         dotnet build src\Cassandra.sln -c Release
 
-        dotnet test src\Cassandra.IntegrationTests\Cassandra.IntegrationTests.csproj -c Release -f net461 --filter "(TestCategory=serverapi)" --logger:Appveyor
+        dotnet test src\Cassandra.IntegrationTests\Cassandra.IntegrationTests.csproj -c Release -f net462 --filter "(TestCategory=serverapi)" --logger:Appveyor
   - matrix:
       only:
         - DRIVER_REPO: "cpp-driver"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -45,9 +45,10 @@ for:
       - export DOTNET_CLI_TELEMETRY_OPTOUT=1
       - export CASSANDRA_VERSION=${CCM_VERSION}
       - export CCM_SSL_PATH=$CCM_PATH/ssl
+      - export BuildAllTargets=True
       - dotnet --version
       - dotnet restore src
-      - dotnet test src/Cassandra.IntegrationTests/Cassandra.IntegrationTests.csproj -f netcoreapp2.1 -c Release --filter TestCategory=serverapi --logger:Appveyor
+      - dotnet test src/Cassandra.IntegrationTests/Cassandra.IntegrationTests.csproj -f netcoreapp3.1 -c Release --filter TestCategory=serverapi --logger:Appveyor
   - matrix:
       only:
         - DRIVER_REPO: "csharp-driver"
@@ -56,17 +57,18 @@ for:
       - ps: .\install_windows.ps1
     test_script:
     - ps: |
-        git checkout ${DRIVER_LATEST_TAG}
+        git checkout $env:DRIVER_LATEST_TAG
 
         $env:CASSANDRA_VERSION=$env:CCM_VERSION
         $env:CCM_SSL_PATH="$env:CCM_PATH\ssl"
         $env:DOTNET_CLI_TELEMETRY_OPTOUT=1
+        $env:BuildAllTargets="True"
 
         dotnet --info
         dotnet restore src
         dotnet build src\Cassandra.sln -c Release
 
-        dotnet test src\Cassandra.IntegrationTests\Cassandra.IntegrationTests.csproj -c Release -f net461 --filter "(TestCategory=serverapi)" --logger:Appveyor
+        dotnet test src\Cassandra.IntegrationTests\Cassandra.IntegrationTests.csproj -c Release -f net462 --filter "(TestCategory=serverapi)" --logger:Appveyor
   - matrix:
       only:
         - DRIVER_REPO: "cpp-driver"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,7 +2,7 @@ stack: node 12, jdk 8, python 2
 
 environment:
   global:
-    CCM_SHA_VERSION: 32e8c1126baeddc21357b414c5b8551d4540fd5f
+    CCM_SHA_VERSION: ecaf6c906177d8ce042e081bf5e37ed3502c80f2
   matrix:
     - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
       DRIVER_REPO: csharp-driver

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -45,7 +45,6 @@ for:
       - export DOTNET_CLI_TELEMETRY_OPTOUT=1
       - export CASSANDRA_VERSION=${CCM_VERSION}
       - export CCM_SSL_PATH=$CCM_PATH/ssl
-      - export BuildAllTargets=True
       - dotnet --version
       - dotnet restore src
       - dotnet test src/Cassandra.IntegrationTests/Cassandra.IntegrationTests.csproj -f netcoreapp2.1 -c Release --filter TestCategory=serverapi --logger:Appveyor
@@ -62,7 +61,6 @@ for:
         $env:CASSANDRA_VERSION=$env:CCM_VERSION
         $env:CCM_SSL_PATH="$env:CCM_PATH\ssl"
         $env:DOTNET_CLI_TELEMETRY_OPTOUT=1
-        $env:BuildAllTargets="True"
 
         dotnet --info
         dotnet restore src

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -48,7 +48,7 @@ for:
       - export BuildAllTargets=True
       - dotnet --version
       - dotnet restore src
-      - dotnet test src/Cassandra.IntegrationTests/Cassandra.IntegrationTests.csproj -f netcoreapp3.1 -c Release --filter TestCategory=serverapi --logger:Appveyor
+      - dotnet test src/Cassandra.IntegrationTests/Cassandra.IntegrationTests.csproj -f netcoreapp2.1 -c Release --filter TestCategory=serverapi --logger:Appveyor
   - matrix:
       only:
         - DRIVER_REPO: "csharp-driver"
@@ -68,7 +68,7 @@ for:
         dotnet restore src
         dotnet build src\Cassandra.sln -c Release
 
-        dotnet test src\Cassandra.IntegrationTests\Cassandra.IntegrationTests.csproj -c Release -f net462 --filter "(TestCategory=serverapi)" --logger:Appveyor
+        dotnet test src\Cassandra.IntegrationTests\Cassandra.IntegrationTests.csproj -c Release -f net461 --filter "(TestCategory=serverapi)" --logger:Appveyor
   - matrix:
       only:
         - DRIVER_REPO: "cpp-driver"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -43,7 +43,8 @@ for:
         - DRIVER_REPO: "csharp-driver"
           APPVEYOR_BUILD_WORKER_IMAGE: Ubuntu
     test_script:
-      - git checkout ${DRIVER_LATEST_TAG}
+      #- git checkout ${DRIVER_LATEST_TAG} ## 3.15.0 tests have an issue with latest ccm
+      - git checkout master
       - export DOTNET_CLI_TELEMETRY_OPTOUT=1
       - export CASSANDRA_VERSION=${CCM_VERSION}
       - export CCM_SSL_PATH=$CCM_PATH/ssl
@@ -58,7 +59,8 @@ for:
       - ps: .\install_windows.ps1
     test_script:
     - ps: |
-        git checkout $env:DRIVER_LATEST_TAG
+        //git checkout $env:DRIVER_LATEST_TAG // 3.15.0 tests have an issue with latest ccm
+        git checkout master
 
         $env:CASSANDRA_VERSION=$env:CCM_VERSION
         $env:CCM_SSL_PATH="$env:CCM_PATH\ssl"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,7 +2,7 @@ stack: node 12, jdk 8, python 2
 
 environment:
   global:
-    CCM_SHA_VERSION: ecaf6c906177d8ce042e081bf5e37ed3502c80f2
+    CCM_SHA_VERSION: 97e3736d4c29bd86878d2b3372f757d18fc89520
   matrix:
     - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
       DRIVER_REPO: csharp-driver

--- a/install.sh
+++ b/install.sh
@@ -12,6 +12,7 @@ fi
 # Install CCM
 git clone --branch master --single-branch https://github.com/riptano/ccm.git
 pushd ccm || exit
+git reset --hard ${CCM_SHA_VERSION}
 sudo python setup.py install
 popd
 ccm status || true

--- a/install_windows.ps1
+++ b/install_windows.ps1
@@ -85,4 +85,5 @@ git clone https://github.com/datastax/$env:DRIVER_REPO
 cd $env:DRIVER_REPO
 
 $env:DRIVER_LATEST_TAG=(git describe --tags (git rev-list --tags --max-count=1)) | Out-String
+$env:DRIVER_LATEST_TAG = $env:DRIVER_LATEST_TAG -replace "`r`n",""
 Write-Host $Env:DRIVER_LATEST_TAG

--- a/install_windows.ps1
+++ b/install_windows.ps1
@@ -83,3 +83,6 @@ ccm remove test
 # Clone the driver repository
 git clone https://github.com/datastax/$env:DRIVER_REPO
 cd $env:DRIVER_REPO
+
+$env:DRIVER_LATEST_TAG=(git describe --tags (git rev-list --tags --max-count=1)) | Out-String
+Write-Host $Env:DRIVER_LATEST_TAG

--- a/install_windows.ps1
+++ b/install_windows.ps1
@@ -54,6 +54,7 @@ If (!(Test-Path $env:CCM_PATH)) {
   Start-Process git -ArgumentList "clone https://github.com/pcmanus/ccm.git $($env:CCM_PATH)" -Wait -NoNewWindow
   Write-Host "git ccm cloned"
   pushd $env:CCM_PATH
+  Start-Process git -ArgumentList "reset --hard $($Env:CCM_SHA_VERSION)" -Wait -NoNewWindow
   Start-Process python -ArgumentList "setup.py install" -Wait -NoNewWindow
   popd
 }
@@ -77,8 +78,7 @@ $Utf8NoBomEncoding = New-Object System.Text.UTF8Encoding $False
 [System.IO.File]::WriteAllText($MyPath, $env:CCM_VERSION, $Utf8NoBomEncoding)
 
 # Verify that ccm cluster creation succeeds
-ccm create test -v $env:CCM_VERSION -n 3
-ccm start test
+ccm create test -v $env:CCM_VERSION
 ccm remove test
 
 # Clone the driver repository

--- a/install_windows.ps1
+++ b/install_windows.ps1
@@ -77,7 +77,8 @@ $Utf8NoBomEncoding = New-Object System.Text.UTF8Encoding $False
 [System.IO.File]::WriteAllText($MyPath, $env:CCM_VERSION, $Utf8NoBomEncoding)
 
 # Verify that ccm cluster creation succeeds
-ccm create test -v $env:CCM_VERSION
+ccm create test -v $env:CCM_VERSION -n 3
+ccm start test
 ccm remove test
 
 # Clone the driver repository


### PR DESCRIPTION
~Fixed C# driver target frameworks after recent changes on the C# test project. This should be done on the next release because these tests checkout the latest tag which doesn't include the recent changes.~
~Add DRIVER_LATEST_TAG to the powershell script.~

EDIT: commented out `DRIVER_LATEST_TAG` and going back to using `master` for C# driver tests. See this comment: https://github.com/datastax/cassandra-drivers-smoke-test/pull/9#issuecomment-644908915