### PR TITLE
Add server version to build info

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -18,7 +18,7 @@ environment:
       DRIVER_REPO: cpp-driver
 
 init:
-- ps: Update-AppveyorBuild -Version "$($env:CCM_VERSION)#$($env:appveyor_build_number)" -Message "Apache Cassandra version $($env:CCM_VERSION)`r`nTest run for Apache Cassandra version $($env:CCM_VERSION) using the package at $($env:SERVER_PACKAGE_URL)."
+- ps: Update-AppveyorBuild -Version "$cassandra-($env:CCM_VERSION) ($($env:appveyor_build_number))" -Message "Apache Cassandra version $($env:CCM_VERSION)"
 
 install:
 - source ./install.sh

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -18,7 +18,7 @@ environment:
       DRIVER_REPO: cpp-driver
 
 init:
-- ps: Update-AppveyorBuild -Version "$($env:CCM_VERSION)#$($env:appveyor_build_number)" -Message "Test run for Apache Cassandra version $($env:CCM_VERSION) using the package at $($env:SERVER_PACKAGE_URL)."
+- ps: Update-AppveyorBuild -Version "$($env:CCM_VERSION)#$($env:appveyor_build_number)" -Message "Apache Cassandra version $($env:CCM_VERSION)`r`nTest run for Apache Cassandra version $($env:CCM_VERSION) using the package at $($env:SERVER_PACKAGE_URL)."
 
 install:
 - source ./install.sh

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,5 +1,7 @@
 stack: node 12, jdk 8, python 2
 
+version: '{build}'
+
 environment:
   global:
     CCM_SHA_VERSION: 97e3736d4c29bd86878d2b3372f757d18fc89520
@@ -14,6 +16,9 @@ environment:
       DRIVER_REPO: nodejs-driver
     - APPVEYOR_BUILD_WORKER_IMAGE: Ubuntu
       DRIVER_REPO: cpp-driver
+
+init:
+- ps: Update-AppveyorBuild -Version "$($env:CCM_VERSION)#$($env:appveyor_build_number)" -Message "Test run for Apache Cassandra version $($env:CCM_VERSION) using the package at $($env:SERVER_PACKAGE_URL)."
 
 install:
 - source ./install.sh

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -17,9 +17,6 @@ environment:
     - APPVEYOR_BUILD_WORKER_IMAGE: Ubuntu
       DRIVER_REPO: cpp-driver
 
-init:
-- ps: Update-AppveyorBuild -Version "$cassandra-($env:CCM_VERSION) ($($env:appveyor_build_number))" -Message "Apache Cassandra version $($env:CCM_VERSION)"
-
 install:
 - source ./install.sh
 
@@ -61,6 +58,8 @@ for:
       only:
         - DRIVER_REPO: "csharp-driver"
           APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
+    init:
+      - ps: Update-AppveyorBuild -Version "$($env:CCM_VERSION)#$($env:appveyor_build_number)" -Message "Apache Cassandra version $($env:CCM_VERSION)`r`nTest run for Apache Cassandra version $($env:CCM_VERSION) using the package at $($env:SERVER_PACKAGE_URL)."
     install:
       - ps: .\install_windows.ps1
     test_script:


### PR DESCRIPTION
Change build version to be {SERVER_VERSION}{BUILD_NUMBER} and build name to always be `Apache Cassandra version {SERVER_VERSION}` instead of picking up the commit message.